### PR TITLE
Don't run CI on Windows/Julia 1.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,6 +28,9 @@ jobs:
           - windows-latest
         arch:
           - x64
+        exclude:
+          - version: '1.6'
+            os: 'windows-latest'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
That job is too slow (3x slower than Windows/Julia 1.0).

Still run CI on mac/linux and 1.6 and windows on 1.0, 1, and nightly 