### PR TITLE
Put back doctests

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,5 +1,9 @@
 ```@meta
 CurrentModule = Chairmarks
+DocTestSetup = quote
+    using Chairmarks
+end
+DocTestFilters = [r"\d\d?\d?\.\d{3} [μmn]?s( \(.*\))?"]
 ```
 
 # Chairmarks
@@ -10,7 +14,7 @@ CurrentModule = Chairmarks
 
 Capable of detecting 1% difference in runtime in ideal conditions
 
-```julia
+```jldoctest
 julia> f(n) = sum(rand() for _ in 1:n)
 f (generic function with 1 method)
 
@@ -37,28 +41,28 @@ julia> @b f(1010)
 
 Chairmarks uses a concise pipeline syntax to define benchmarks. When providing a single argument, that argument is automatically wrapped in a function for higher performance and executed
 
-```julia
+```jldoctest
 julia> @b sort(rand(100))
 1.500 μs (3 allocs: 2.625 KiB)
 ```
 
 When providing two arguments, the first is setup code and only the runtime of the second is measured
 
-```julia
+```jldoctest
 julia> @b rand(100) sort
 1.018 μs (2 allocs: 1.750 KiB)
 ```
 
 You may use `_` in the later arguments to refer to the output of previous arguments
 
-```julia
+```jldoctest
 julia> @b rand(100) sort(_, by=x -> exp(-x))
 5.521 μs (2 allocs: 1.750 KiB)
 ```
 
 A third argument can run a "teardown" function to integrate testing into the benchmark and ensure that the benchmarked code is behaving correctly
 
-```julia
+```jldoctest
 julia> @b rand(100) sort(_, by=x -> exp(-x)) issorted(_) || error()
 ERROR:
 Stacktrace:

--- a/src/public.jl
+++ b/src/public.jl
@@ -88,7 +88,7 @@ $(replace(DOCSTRING_BODY, "@bx" => "@b"))
 
 # Examples
 
-```julia
+```jldoctest; filter = [r"\\d\\d?\\d?\\.\\d{3} [μmn]?s( \\(.*\\))?"=>s"RES"], setup=(using Random)
 julia> @b rand(10000) # Benchmark a function
 5.833 μs (2 allocs: 78.172 KiB)
 
@@ -130,7 +130,7 @@ $(replace(DOCSTRING_BODY, "@bx" => "@be"))
 
 # Examples
 
-```julia
+```jldoctest;  filter = [r"\\d\\d?\\d?\\.\\d{3} [μmn]?s( \\(.*\\))?"=>s"RES", r"\\d+ (sample|evaluation)s?"=>s"### \\1"], setup=(using Random)
 julia> @be rand(10000) # Benchmark a function
 Benchmark: 267 samples with 2 evaluations
 min    8.500 μs (2 allocs: 78.172 KiB)


### PR DESCRIPTION
The doctests test as much as possible while still being entirely performance independent. Something could be doctested to take 1ns and end up taking 10s with compile time, gc time, etc and it would still pass doctests.

The one exception to this is changing number of samples below 5 when displaying a full `@be` result i.e. crossing between these sets (1, 2, 3, 4, 5:inf).

Excludes the README because they are copied directly from index.md & wouldn't actually run anyway.