### PR TITLE
Add display tests and fix Sample constructor, display on old versions, and display of empty benchmarks

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -107,6 +107,7 @@ function Base.show(io::IO, m::MIME"text/plain", b::Benchmark)
     samples = length(b.data)
     print(io, "Benchmark: $samples sample")
     samples == 1 || print(io, "s")
+    samples == 0 && return
     print(io, " with ")
     if all(==(first(b.data).evals), getproperty.(b.data, :evals)) # allequal not defined in Julia <1.8
         evals = first(b.data).evals

--- a/src/show.jl
+++ b/src/show.jl
@@ -108,7 +108,7 @@ function Base.show(io::IO, m::MIME"text/plain", b::Benchmark)
     print(io, "Benchmark: $samples sample")
     samples == 1 || print(io, "s")
     print(io, " with ")
-    if all(==(b.data[0].evals), getproperty.(b.data, :evals)) # allequal not defined in Julia <1.8
+    if all(==(first(b.data).evals), getproperty.(b.data, :evals)) # allequal not defined in Julia <1.8
         evals = first(b.data).evals
         print_maybe_int(io, "", first(b.data).evals, " evaluation")
         evals == 1 || print(io, "s")

--- a/src/show.jl
+++ b/src/show.jl
@@ -5,7 +5,7 @@ function print_rounded(@nospecialize(io::IO), x::Float64, digits::Int)
     elseif 0 < x < 1/10^digits
         print(io, "<0.", '0'^(digits-1), "1")
     else
-        print(io, Base.Ryu.writefixed(x, digits))
+        print(io, VERSION < v"1.6" ? string(x) : Base.Ryu.writefixed(x, digits))
     end
 end
 function print_time(io, seconds::Float64)
@@ -108,7 +108,7 @@ function Base.show(io::IO, m::MIME"text/plain", b::Benchmark)
     print(io, "Benchmark: $samples sample")
     samples == 1 || print(io, "s")
     print(io, " with ")
-    if allequal(getproperty.(b.data, :evals))
+    if all(==(b.data[0].evals), getproperty.(b.data, :evals)) # allequal not defined in Julia <1.8
         evals = first(b.data).evals
         print_maybe_int(io, "", first(b.data).evals, " evaluation")
         evals == 1 || print(io, "s")

--- a/src/types.jl
+++ b/src/types.jl
@@ -42,8 +42,8 @@ struct Sample
     "The value returned by the accumulator"
     value              ::Float64
 end
-Sample(; evals=1, time, allocs=0, bytes=0, gc_fraction=0, compile_fraction=0, recompile_fraction=0, warmup=true) =
-    Sample(evals, time, allocs, bytes, gc_fraction, compile_fraction, recompile_fraction, warmup)
+Sample(; evals=1, time, allocs=0, bytes=0, gc_fraction=0, compile_fraction=0, recompile_fraction=0, warmup=true, value=0) =
+    Sample(evals, time, allocs, bytes, gc_fraction, compile_fraction, recompile_fraction, warmup, value)
 
 struct Benchmark
     data::Vector{Sample}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,6 +78,10 @@ using Chairmarks: Sample, Benchmark
                    101.540 ms (166 allocs: 16.195 KiB)
                    101.591 ms (166 allocs: 16.195 KiB)
                    102.239 ms (166 allocs: 16.195 KiB)"""
+
+            x = Benchmark(x.data[1:0])
+            @test eval(Meta.parse(repr(x))).data == x.data
+            @test sprint(show, MIME"text/plain"(), x) == "Benchmark: 0 samples"
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,11 +46,13 @@ using Chairmarks: Sample, Benchmark
             x = Sample(evals=20076, time=2.822275353656107e-10)
             @test repr(x) == "Sample(evals=20076, time=2.822275353656107e-10)"
             @test eval(Meta.parse(repr(x))) === x
-            @test sprint(show, MIME"text/plain"(), x) == "0.282 ns"
+            @test sprint(show, MIME"text/plain"(), x) == (VERSION < v"1.6" ? "0.28222753536561074 ns" : "0.282 ns")
 
             x = Sample(time=1.013617427, allocs=30354, bytes=2045496, compile_fraction=0.01090194061945622, recompile_fraction=0.474822474626834, warmup=0)
             @test eval(Meta.parse(repr(x))) === x
-            @test sprint(show, MIME"text/plain"(), x) == "1.014 s (30354 allocs: 1.951 MiB, 1.09% compile time 47.48% of which was recompilation, without a warmup)"
+            @test sprint(show, MIME"text/plain"(), x) == (VERSION < v"1.6" ?
+                "1.014 s (30354 allocs: 1.951 MiB, 1.0901940619456219% compile time 47.482247462683404% of which was recompilation, without a warmup)" :
+                "1.014 s (30354 allocs: 1.951 MiB, 1.09% compile time 47.48% of which was recompilation, without a warmup)")
 
             x = Benchmark([
                 Sample(time=0.10223923, allocs=166, bytes=16584)
@@ -61,7 +63,7 @@ using Chairmarks: Sample, Benchmark
             ])
 
             @test eval(Meta.parse(repr(x))).data == x.data
-            @test sprint(show, MIME"text/plain"(), x) == """
+            VERSION >= v"1.6" && @test sprint(show, MIME"text/plain"(), x) == """
             Benchmark: 5 samples with 1 evaluation
             min    101.540 ms (166 allocs: 16.195 KiB)
             median 101.623 ms (166 allocs: 16.195 KiB)
@@ -71,7 +73,7 @@ using Chairmarks: Sample, Benchmark
             x = Benchmark(x.data[1:3])
 
             @test eval(Meta.parse(repr(x))).data == x.data
-            @test sprint(show, MIME"text/plain"(), x) == """
+            VERSION >= v"1.6" && @test sprint(show, MIME"text/plain"(), x) == """
             Benchmark: 3 samples with 1 evaluation
                    101.540 ms (166 allocs: 16.195 KiB)
                    101.591 ms (166 allocs: 16.195 KiB)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Chairmarks
 using Test
 using Statistics
+using Chairmarks: Sample, Benchmark
 
 @testset "Chairmarks" begin
     @testset "Standard tests" begin
@@ -39,6 +40,42 @@ using Statistics
         @testset "seconds kw" begin
             @b 1+1 seconds=1
             @b 1+1 seconds=.001
+        end
+
+        @testset "display" begin
+            x = Sample(evals=20076, time=2.822275353656107e-10)
+            @test repr(x) == "Sample(evals=20076, time=2.822275353656107e-10)"
+            @test eval(Meta.parse(repr(x))) === x
+            @test sprint(show, MIME"text/plain"(), x) == "0.282 ns"
+
+            x = Sample(time=1.013617427, allocs=30354, bytes=2045496, compile_fraction=0.01090194061945622, recompile_fraction=0.474822474626834, warmup=0)
+            @test eval(Meta.parse(repr(x))) === x
+            @test sprint(show, MIME"text/plain"(), x) == "1.014 s (30354 allocs: 1.951 MiB, 1.09% compile time 47.48% of which was recompilation, without a warmup)"
+
+            x = Benchmark([
+                Sample(time=0.10223923, allocs=166, bytes=16584)
+                Sample(time=0.101591227, allocs=166, bytes=16584)
+                Sample(time=0.10154031000000001, allocs=166, bytes=16584)
+                Sample(time=0.101644144, allocs=166, bytes=16584)
+                Sample(time=0.10162322700000001, allocs=166, bytes=16584)
+            ])
+
+            @test eval(Meta.parse(repr(x))).data == x.data
+            @test sprint(show, MIME"text/plain"(), x) == """
+            Benchmark: 5 samples with 1 evaluation
+            min    101.540 ms (166 allocs: 16.195 KiB)
+            median 101.623 ms (166 allocs: 16.195 KiB)
+            mean   101.728 ms (166 allocs: 16.195 KiB)
+            max    102.239 ms (166 allocs: 16.195 KiB)"""
+
+            x = Benchmark(x.data[1:3])
+
+            @test eval(Meta.parse(repr(x))).data == x.data
+            @test sprint(show, MIME"text/plain"(), x) == """
+            Benchmark: 3 samples with 1 evaluation
+                   101.540 ms (166 allocs: 16.195 KiB)
+                   101.591 ms (166 allocs: 16.195 KiB)
+                   102.239 ms (166 allocs: 16.195 KiB)"""
         end
     end
 


### PR DESCRIPTION
The doctests don't adequately cover display testing because they filter out alot of important information to be insensitive to noise. These tests use static fabricated data to avoid that.

Revealed a bug in a `Sample` constructor that is only used to make `repr` output `eval`able