### PR TITLE
Don't de-optimize `@b lit` where `lit` is a literal constant.

### DIFF
--- a/src/macro_tools.jl
+++ b/src/macro_tools.jl
@@ -15,9 +15,9 @@ function substitute(ex::Expr, var::Symbol)
     changed ? exprarray(ex.head, args) : ex, changed
 end
 
-create_first_function(f::Symbol) = f
-create_first_function(x) = Returns(x)
-create_first_function(body::Expr) = :(() -> $body)
+# This could be `Returns` for literals, symbols, etc, but `Returns` has weaker type
+# information and I don't want `2.0` to be slower than `1.0+1.0` or `x` where `x` is `const`
+create_first_function(body) = :(() -> $body)
 function create_function(f)
     f === :_ && return identity
     var = gensym()

--- a/src/macro_tools.jl
+++ b/src/macro_tools.jl
@@ -15,9 +15,6 @@ function substitute(ex::Expr, var::Symbol)
     changed ? exprarray(ex.head, args) : ex, changed
 end
 
-# This could be `Returns` for literals, symbols, etc, but `Returns` has weaker type
-# information and I don't want `2.0` to be slower than `1.0+1.0` or `x` where `x` is `const`
-create_first_function(body) = :(() -> $body)
 function create_function(f)
     f === :_ && return identity
     var = gensym()
@@ -40,7 +37,10 @@ function process_args(exprs)
         elseif ex === :_
             push!(args, nothing)
         elseif first
-            push!(args, create_first_function(ex))
+            # This could be `Returns` for literals, symbols, etc, but `Returns` has weaker
+            # type information and I don't want `2.0` to be slower than `1.0+1.0` or `x`
+            # where `x` is a `const`.
+            push!(args, :(() -> $body))
             first = false
         else
             push!(args, create_function(ex))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,11 @@ using Chairmarks: Sample, Benchmark
             @b 1+1 seconds=.001
         end
 
+        @testset "symbol as first arg" begin
+            x = 2
+            @b x
+        end
+
         @testset "errors" begin
             @test_throws UndefKeywordError Sample(allocs=1.5, bytes=1729) # needs `time`
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -180,12 +180,12 @@ using Chairmarks: Sample, Benchmark
             @test nonzero(@b rand _^3)
             @test nonzero(@b rand _^4)
             @test nonzero(@b rand _^5)
-            @test nonzero(@b 0)
-            @test nonzero(@b 1)
+            @test nonzero(@b 2)
+            @test nonzero(@b 123908)
             @test nonzero(@b -10923740)
 
-            @test_broken (@b 1).time == 0
-            @test_broken (@b 123908).time == 0
+            @test_broken (@b 0).time != 0
+            @test_broken (@b 1).time != 0
         end
 
         @testset "Near monotonicity for evalpoly" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,7 +44,7 @@ using Chairmarks: Sample, Benchmark
 
         @testset "symbol as first arg" begin
             x = 2
-            @b x
+            @test_throws MethodError @b x
         end
 
         @testset "errors" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -184,8 +184,8 @@ using Chairmarks: Sample, Benchmark
             @test nonzero(@b 123908)
             @test nonzero(@b -10923740)
 
-            @test_broken (@b 0).time != 0
-            @test_broken (@b 1).time != 0
+            @test_skip nonzero(@b 0)
+            @test_skip nonzero(@b 1)
         end
 
         @testset "Near monotonicity for evalpoly" begin


### PR DESCRIPTION
Makes `@b 1+1` and `@b 2` equivalent.

It's unclear if this is worth doing.