### PR TITLE
Better calibration result handling

### DIFF
--- a/src/benchmarking.jl
+++ b/src/benchmarking.jl
@@ -50,7 +50,7 @@ function benchmark(init, setup, f, teardown; evals::Union{Int, Nothing}=nothing,
         if calibration1.time < .00015seconds # This branch protects us against cases where runtime is dominated by the reduction.
             calibration2, time = bench(10)
             trials = floor(Int, .05seconds/(calibration2.time+1e-9))
-            if trials > 10
+            if trials > 20
                 calibration2, time = bench(trials)
             end
         elseif calibration1.time < .01seconds

--- a/src/benchmarking.jl
+++ b/src/benchmarking.jl
@@ -47,9 +47,14 @@ function benchmark(init, setup, f, teardown; evals::Union{Int, Nothing}=nothing,
         # We should be spending about 5% of runtime on calibration.
         # If we spent less than 1% then recalibrate with more evals.
         calibration2 = nothing
-        if calibration1.time < .01seconds
-            caltime = calibration1.time < .00015seconds ? bench(10)[1].time : calibration1.time # This line protects us against cases where runtime is dominated by the reduction.
-            calibration2, time = bench(floor(Int, .05seconds/(caltime+1e-9)))
+        if calibration1.time < .00015seconds # This branch protects us against cases where runtime is dominated by the reduction.
+            calibration2, time = bench(10)
+            trials = floor(Int, .05seconds/(calibration2.time+1e-9))
+            if trials > 10
+                calibration2, time = bench(trials)
+            end
+        elseif calibration1.time < .01seconds
+            calibration2, time = bench(floor(Int, .05seconds/(calibration1.time+1e-9)))
         end
 
         # We need samples that take at least 30 nanoseconds for any reasonable measurements


### PR DESCRIPTION
When we decide to run a bench(10) as pre-calibration because the `bench(1)` call was too fast (less than .015% of total budget/0.3% of calibration budget), and then that calibration takes too long (e.g. 10% of total budget), use its results instead of replacing it with `bench(0)` (or any number <= 20). This can happen when `bench(1)` gives a result of `0` due to low timekeeping precision, and `bench(10)` gives a high result due to low total budged.

Fixes #24, an issue that occurs when the time budget is low compared to the clock resolution.

TODO: consider simplifying and/or refactoring calibration system. Esp considering the possibility of low precision clocks.