### PR TITLE
Release 0.3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Chairmarks"
 uuid = "0ca39b1e-fe0b-4e98-acfc-b1656634c4de"
 authors = ["Lilith Orion Hafner <lilithhafner@gmail.com> and contributors"]
-version = "0.2.3"
+version = "0.3.0"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -85,10 +85,10 @@ its return value.
 While the checksums are fast, one negative side effect of this is that they add a bit of
 overhead to the measured runtime, and that overhead can vary depending on the function being
 benchmarked. These checksums are performed by computing a map over the returned values and a
-reduction over those mapped values. You can disable this by overwriting the map with
-something trivial. For example, `map=Returns(nothing)`, possibly in combination with a
-custom teardown function that verifies computation results. Be aware that as the compiler
-improves, it may become better at eliding benchmarks whose results are not saved.
+reduction over those mapped values. You can disable this by passing the `checksum=false`
+keyword argument, possibly in combination with a custom teardown function that verifies
+computation results. Be aware that as the compiler improves, it may become better at eliding
+benchmarks whose results are not saved.
 
 ```jldoctest; filter=r"\d\d?\d?\.\d{3} [μmn]?s( \(.*\))?|0 ns|<0.001 ns"
 julia> @b 1
@@ -97,9 +97,13 @@ julia> @b 1
 julia> @b 1.0
 1.135 ns
 
-julia> @b 1.0 map=Returns(nothing)
+julia> @b 1.0 checksum=false
 0 ns
 ```
+
+You may experiment with custom reductions using the internal _map and _reduction keyword
+arguments. The default maps and reductions (`Chairmarks.default_map` and
+`Chairmarks.default_reduction`) are internal and subject to change and/or removal in future.
 
 ## Efficient
 

--- a/src/benchmarking.jl
+++ b/src/benchmarking.jl
@@ -12,7 +12,7 @@ maybecall(::Nothing, x::Tuple{}) = x
 maybecall(f, x::Tuple{Any}) = (f(only(x)),)
 maybecall(f::Function, ::Tuple{}) = (f(),)
 maybecall(x, ::Tuple{}) = (x,)
-function benchmark(init, setup, f, teardown; evals::Union{Int, Nothing}=nothing, samples::Union{Int, Nothing}=nothing, seconds::Union{Real, Nothing}=samples===nothing ? .1 : 1, map=default_map, reduction=default_reduction)
+function benchmark(init, setup, f, teardown; evals::Union{Int, Nothing}=nothing, samples::Union{Int, Nothing}=nothing, seconds::Union{Real, Nothing}=samples===nothing ? .1 : 1, checksum::Bool=true, _map=(checksum ? default_map : Returns(nothing)), _reduction=default_reduction)
     @nospecialize
     samples !== nothing && evals === nothing && throw(ArgumentError("Sorry, we don't support specifying samples but not evals"))
     samples === seconds === nothing && throw(ArgumentError("Must specify either samples or seconds"))
@@ -24,7 +24,7 @@ function benchmark(init, setup, f, teardown; evals::Union{Int, Nothing}=nothing,
 
     function bench(evals, warmup=true)
         args2 = maybecall(setup, args1)
-        sample, t, args3 = _benchmark(f, map, reduction, args2, evals, warmup)
+        sample, t, args3 = _benchmark(f, _map, _reduction, args2, evals, warmup)
         maybecall(teardown, (args3,))
         sample, t
     end


### PR DESCRIPTION
Make the map and reduction arguments internal and rename them to _map and _reduction (a breaking change)