### PR TITLE
Rename `value` to `checksum`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -285,7 +285,7 @@ Benchmark results have the following fields:
 | x.compile_fraction   | N/A               | Fraction of time spent compiling |
 | x.recompile_fraction | N/A               | Fraction of time spent compiling which was on recompilation |
 | x.warmup             | true              | weather or not the sample had a warmup run before it |
-| x.value              | N/A               | a checksum computed from the return values of the benchmarked code |
+| x.checksum           | N/A               | a checksum computed from the return values of the benchmarked code |
 | x.evals              | x.params.evals    | the number of evaluations in the sample |
 
 Note that these fields are likely to change in Chairmarks 1.0.

--- a/src/types.jl
+++ b/src/types.jl
@@ -39,11 +39,11 @@ struct Sample
     "Whether this sample had a warmup run before it (1.0 = yes. 0.0 = no)."
     warmup             ::Float64
 
-    "The value returned by the accumulator"
-    value              ::Float64
+    "The checksum value returned by the accumulator"
+    checksum              ::Float64
 end
-Sample(; evals=1, time, allocs=0, bytes=0, gc_fraction=0, compile_fraction=0, recompile_fraction=0, warmup=true, value=0) =
-    Sample(evals, time, allocs, bytes, gc_fraction, compile_fraction, recompile_fraction, warmup, value)
+Sample(; evals=1, time, allocs=0, bytes=0, gc_fraction=0, compile_fraction=0, recompile_fraction=0, warmup=true, checksum=0) =
+    Sample(evals, time, allocs, bytes, gc_fraction, compile_fraction, recompile_fraction, warmup, checksum)
 
 struct Benchmark
     data::Vector{Sample}


### PR DESCRIPTION
It's a checksum because it contains no useful information about the returned values and is confined to a single Float64.