### PR TITLE
Concision and crosslinking in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ julia> @b rand(1000) _.*5 # How long does it take to multiply it by 5 element wi
 172.970 ns (3 allocs: 7.875 KiB)
 ```
 
-[Why Chairmarks?](https://Chairmarks.lilithhafner.com/stable/why.html)
+[Why Chairmarks?](https://Chairmarks.lilithhafner.com/stable/why)
 
-[Tutorial](https://Chairmarks.lilithhafner.com/stable/tutorial.html)
+[Tutorial](https://Chairmarks.lilithhafner.com/stable/tutorial)
 
-[API Reference](https://Chairmarks.lilithhafner.com/stable/reference.html)
+[API Reference](https://Chairmarks.lilithhafner.com/stable/reference)

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![Build Status](https://github.com/LilithHafner/Chairmarks.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/LilithHafner/Chairmarks.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/LilithHafner/Chairmarks.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/LilithHafner/Chairmarks.jl)
 
-Chairmarks measures performance [hundreds of times faster](https://Chairmarks.lilithhafner.com/stable/why.html#Efficient)
-than BenchmarkTools [without compromising on accuracy](https://Chairmarks.lilithhafner.com/stable/why.html#Precise).
+Chairmarks measures performance [hundreds of times faster](https://Chairmarks.lilithhafner.com/stable/why.html/#Efficient)
+than BenchmarkTools [without compromising on accuracy](https://Chairmarks.lilithhafner.com/stable/why.html/#Precise).
 
 Installation
 

--- a/README.md
+++ b/README.md
@@ -5,106 +5,32 @@
 [![Build Status](https://github.com/LilithHafner/Chairmarks.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/LilithHafner/Chairmarks.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/LilithHafner/Chairmarks.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/LilithHafner/Chairmarks.jl)
 
-Benchmarks with back support. Often hundreds of times faster than BenchmarkTools.jl without compromising on accuracy.
+Chairmarks measures performance [hundreds of times faster](https://Chairmarks.lilithhafner.com/stable/why.html#Efficient)
+than BenchmarkTools [without compromising on accuracy](https://Chairmarks.lilithhafner.com/stable/why.html#Precise).
 
-## Precise
+Installation
 
-Capable of detecting 1% difference in runtime in ideal conditions
-
-```julia
-julia> f(n) = sum(rand() for _ in 1:n)
-f (generic function with 1 method)
-
-julia> @b f(1000)
-1.074 μs
-
-julia> @b f(1000)
-1.075 μs
-
-julia> @b f(1000)
-1.076 μs
-
-julia> @b f(1010)
-1.086 μs
-
-julia> @b f(1010)
-1.087 μs
-
-julia> @b f(1010)
-1.087 μs
+```julia-repl
+julia> import Pkg; Pkg.add("Chairmarks")
 ```
 
-## Concise
+Usage
 
-Chairmarks uses a concise pipeline syntax to define benchmarks. When providing a single argument, that argument is automatically wrapped in a function for higher performance and executed
+```jldoctest
+julia> using Chairmarks
 
-```julia
-julia> @b sort(rand(100))
-1.500 μs (3 allocs: 2.625 KiB)
+julia> @b rand(1000) # How long does it take to generate a random array of length 1000?
+720.214 ns (3 allocs: 7.875 KiB)
+
+julia> @b rand(1000) hash # How long does it take to hash that array?
+1.689 μs
+
+julia> @b rand(1000) _.*5 # How long does it take to multiply it by 5 element wise?
+172.970 ns (3 allocs: 7.875 KiB)
 ```
 
-When providing two arguments, the first is setup code and only the runtime of the second is measured
+[Why Chairmarks?](https://Chairmarks.lilithhafner.com/stable/why.html)
 
-```julia
-julia> @b rand(100) sort
-1.018 μs (2 allocs: 1.750 KiB)
-```
+[Tutorial](https://Chairmarks.lilithhafner.com/stable/tutorial.html)
 
-You may use `_` in the later arguments to refer to the output of previous arguments
-
-```julia
-julia> @b rand(100) sort(_, by=x -> exp(-x))
-5.521 μs (2 allocs: 1.750 KiB)
-```
-
-A third argument can run a "teardown" function to integrate testing into the benchmark and ensure that the benchmarked code is behaving correctly
-
-```julia
-julia> @b rand(100) sort(_, by=x -> exp(-x)) issorted(_) || error()
-ERROR:
-Stacktrace:
- [1] error()
-[...]
-
-julia> @b rand(100) sort(_, by=x -> exp(-x)) issorted(_, rev=true) || error()
-5.358 μs (2 allocs: 1.750 KiB)
-```
-
-See the [docstring of `@b`](https://chairmarks.lilithhafner.com/dev/#Chairmarks.@b-Tuple) for more info
-
-## Truthful
-
-Charimarks.jl automatically computes a checksum based on the results of the provided
-computations, and returns that checksum to the user along with benchmark results. This makes
-it impossible for the compiler to elide any part of the computation that has an impact on
-its return value.
-
-While the checksums are fast, one negative side effect of this is that they add a bit of
-overhead to the measured runtime, and that overhead can vary depending on the function being
-benchmarked. These checksums are performed by computing a map over the returned values and a
-reduction over those mapped values. You can disable this by overwriting the map with
-something trivial. For example, `map=Returns(nothing)`, possibly in combination with a
-custom teardown function that verifies computation results. Be aware that as the compiler
-improves, it may become better at eliding benchmarks whose results are not saved.
-
-```julia
-julia> @b 1
-0.713 ns
-
-julia> @b 1.0
-1.135 ns
-
-julia> @b 1.0 map=Returns(nothing)
-0 ns
-```
-
-## Efficient
-
-|           | Chairmarks.jl | BenchmarkTools.jl | Ratio
-|-----------|--------|---------------|--------|
-|[TTFX](contrib/ttfx_rm_rf_julia.sh) | 3.4s | 13.4s | 4x
-| Load time | 4.2ms | 131ms | 31x
-| TTFX excluding precompile time | 43ms | 1118ms | 26x
-| minimum runtime | 34μs | 459ms | 13,500x
-|Width | Narrow   | Wide     |     2–4x
-|Back Support | Almost Always | Sometimes | N/A
+[API Reference](https://Chairmarks.lilithhafner.com/stable/reference.html)

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![Build Status](https://github.com/LilithHafner/Chairmarks.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/LilithHafner/Chairmarks.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/LilithHafner/Chairmarks.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/LilithHafner/Chairmarks.jl)
 
-Chairmarks measures performance [hundreds of times faster](https://Chairmarks.lilithhafner.com/stable/why.html/#Efficient)
-than BenchmarkTools [without compromising on accuracy](https://Chairmarks.lilithhafner.com/stable/why.html/#Precise).
+Chairmarks measures performance [hundreds of times faster](https://Chairmarks.lilithhafner.com/stable/why/#Efficient)
+than BenchmarkTools [without compromising on accuracy](https://Chairmarks.lilithhafner.com/stable/why/#Precise).
 
 Installation
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,8 +8,8 @@ DocTestFilters = [r"\d\d?\d?\.\d{3} [μmn]?s( \(.*\))?"]
 
 # Chairmarks
 
-[Chairmarks](https://github.com/LilithHafner/Chairmarks.jl) measures performance hundreds
-of times faster than BenchmarkTools without compromising on accuracy.
+[Chairmarks](https://github.com/LilithHafner/Chairmarks.jl) measures performance [hundreds
+of times faster](@ref Efficient) than BenchmarkTools [without compromising on accuracy](@ref Precise).
 
 Installation
 

--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -113,7 +113,7 @@ julia> x = 6 # nonconstant global
 julia> @b rand(x) # slow
 39.616 ns (1.02 allocs: 112.630 bytes)
 
-julia> f(x) = @b rand(x)
+julia> f(len) = @b rand(len)
 f (generic function with 1 method)
 
 julia> f(x) # fast

--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -116,7 +116,7 @@ julia> @b rand(x) # slow
 julia> f(x) = @b rand(x)
 f (generic function with 1 method)
 
-julia> f(6) # fast
+julia> f(x) # fast
 19.010 ns (1 allocs: 112 bytes)
 
 julia> @b x rand # fast

--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -100,9 +100,11 @@ Note that these fields are likely to change in Chairmarks 1.0.
 The arguments to Chairmarks are lowered to functions, not quoted expressions.
 Consequently, there is no need to interpolate variables and interpolation is therefore not
 supported. Like BenchmarkTools, benchmarks that includes access to nonconstant globals
-will receive a performance overhead for that access. Two possible ways to avoid this are
-to make the global constant, and to include it in the setup or initiaization phase. For
-example,
+will receive a performance overhead for that access. However, Chairmarks evaluates
+expressions in the scope of the macro call, not in global scope, so nonconstant global
+access is much less of an issue in Chairmarks than BenchmarkTools. Three possible ways to
+avoid it are to put the `@b` call in a function, make the global constant, or to include it
+in the setup or initiaization phase. For example,
 
 ```jldoctest
 julia> x = 6 # nonconstant global
@@ -110,6 +112,12 @@ julia> x = 6 # nonconstant global
 
 julia> @b rand(x) # slow
 39.616 ns (1.02 allocs: 112.630 bytes)
+
+julia> f(x) = @b rand(x)
+f (generic function with 1 method)
+
+julia> f(6) # fast
+19.010 ns (1 allocs: 112 bytes)
 
 julia> @b x rand # fast
 18.939 ns (1 allocs: 112 bytes)

--- a/src/Chairmarks.jl
+++ b/src/Chairmarks.jl
@@ -7,9 +7,9 @@ julia> @b evalpooly(rand(), rand(100))
 198.077 ns (2 allocs: 928 bytes)
 ```
 
-Documentation: [https://chairmarks.lilithhafner.com/stable/](@ref https://chairmarks.lilithhafner.com/stable/)
+Documentation: [https://chairmarks.lilithhafner.com/stable/](@ref index)
 
-Tutorial: [https://chairmarks.lilithhafner.com/stable/tutorial.html](@ref https://chairmarks.lilithhafner.com/stable/tutorial.html)
+Tutorial: [https://chairmarks.lilithhafner.com/stable/tutorial.html](@ref tutorial)
 
 Reference: see docstrings of [`@be`](@ref) and [`@b`](@ref)
 """

--- a/src/Chairmarks.jl
+++ b/src/Chairmarks.jl
@@ -7,9 +7,9 @@ julia> @b evalpooly(rand(), rand(100))
 198.077 ns (2 allocs: 928 bytes)
 ```
 
-Documentation: [https://chairmarks.lilithhafner.com/stable/](@ref index)
+Documentation: https://chairmarks.lilithhafner.com/stable
 
-Tutorial: [https://chairmarks.lilithhafner.com/stable/tutorial.html](@ref tutorial)
+Tutorial: https://chairmarks.lilithhafner.com/stable/tutorial.html
 
 Reference: see docstrings of [`@be`](@ref) and [`@b`](@ref)
 """

--- a/src/Chairmarks.jl
+++ b/src/Chairmarks.jl
@@ -1,3 +1,18 @@
+"""
+Chairmarks provides the macros [`@b`](@ref) and [`@be`](@ref) for benchmarking code. See
+their respecitve docstrings for usage.
+
+```julia
+julia> @b evalpooly(rand(), rand(100))
+198.077 ns (2 allocs: 928 bytes)
+```
+
+Documentation: [https://chairmarks.lilithhafner.com/stable/](@ref https://chairmarks.lilithhafner.com/stable/)
+
+Tutorial: [https://chairmarks.lilithhafner.com/stable/tutorial.html](@ref https://chairmarks.lilithhafner.com/stable/tutorial.html)
+
+Reference: see docstrings of [`@be`](@ref) and [`@b`](@ref)
+"""
 module Chairmarks
 
 using Printf


### PR DESCRIPTION
- shorter readme and more links to docs
- add docstring to module (for a shorter docstring than the default

Requires 0.3.1 to be registered and docs stable for links in README to not be broken.