### PR TITLE
Fix and test reporting undef results bug

### DIFF
--- a/src/benchmarking.jl
+++ b/src/benchmarking.jl
@@ -93,6 +93,8 @@ function benchmark(init, setup, f, teardown; evals::Union{Int, Nothing}=nothing,
         samples === nothing ? push!(data, sample) : (data[i += 1] = sample)
     end
 
+    samples === nothing || resize!(data, i-1)
+
     Benchmark(data)
 end
 _div(a, b) = a == b == 0 ? zero(a/b) : a/b

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,6 +41,13 @@ using Chairmarks: Sample, Benchmark
             @b 1+1 seconds=.001
         end
 
+        @testset "seconds-limited while specitying samples (#56)" begin
+            for _ in 1:3 # loop because this requires reading garbage from undef to fail
+                res = @b sleep(.01) evals=2 samples=100 seconds=0.1
+                @test 0.01 < res.time < 10
+            end
+        end
+
         @testset "errors" begin
             @test_throws UndefKeywordError Sample(allocs=1.5, bytes=1729) # needs `time`
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,10 +42,9 @@ using Chairmarks: Sample, Benchmark
         end
 
         @testset "seconds-limited while specitying samples (#56)" begin
-            for _ in 1:3 # loop because this requires reading garbage from undef to fail
-                res = @b sleep(.01) evals=2 samples=100 seconds=0.1
-                @test 0.01 < res.time < 10
-            end
+            res = @be sleep(.01) evals=2 samples=100 seconds=0.1
+            @test 0.01 < minimum(res).time < 10
+            @test length(res.samples) < 100
         end
 
         @testset "errors" begin


### PR DESCRIPTION
Fixes #56. In local tests, the new test failed 3/3 times without the patch.