### PR TITLE
remove ... from docs file names because they don't look nice in Vitepress and are no longer necessary

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,9 +18,9 @@ makedocs(;
         "Why use Chairmarks?" => "why.md",
         "Tutorial" => "tutorial.md",
         "How To" => [
-            "...migrate from BenchmarkTools" => "migration.md",
-            "...install Chairmarks ergonomically" => "autoload.md",
-            "...perform automated regression testing on a package" => "regressions.md",
+            "migrate from BenchmarkTools" => "migration.md",
+            "install Chairmarks ergonomically" => "autoload.md",
+            "perform automated regression testing on a package" => "regressions.md",
         ],
         "Reference" => "reference.md",
         "Explanations" => "explanations.md",


### PR DESCRIPTION
DocumenterVitepress makes these clearly nest withing How to, so the dots are unnecessary.