### PR TITLE
Fix off by one error in sample count

### DIFF
--- a/src/benchmarking.jl
+++ b/src/benchmarking.jl
@@ -103,7 +103,7 @@ function benchmark(init, setup, f, teardown; evals::Union{Int, Nothing}=nothing,
         samples === nothing ? push!(data, sample) : (data[i += 1] = sample)
     end
 
-    samples === nothing || resize!(data, i-1)
+    samples === nothing || resize!(data, i)
 
     Benchmark(data)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,12 +49,12 @@ using Chairmarks: Sample, Benchmark
 
         @testset "low sample count (#91)" begin
             b = @be sleep(.001) evals=4 samples=0
-            @test only(b.samples).warmup == 0
-            @test_broken only(b.samples).evals == 4
+            @test Chairmarks.only(b.samples).warmup == 0 # Qualify only for compat
+            @test_broken Chairmarks.only(b.samples).evals == 4
 
             b = @be sleep(.001) evals=4 samples=1
-            @test only(b.samples).warmup == 1
-            @test only(b.samples).evals == 4
+            @test Chairmarks.only(b.samples).warmup == 1
+            @test Chairmarks.only(b.samples).evals == 4
 
             b = @be sleep(.001) evals=4 samples=2
             @test length(b.samples) == 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,6 +47,20 @@ using Chairmarks: Sample, Benchmark
             @test length(res.samples) < 100
         end
 
+        @testset "low sample count (#91)" begin
+            b = @be sleep(.001) evals=4 samples=0
+            @test only(b.samples).warmup == 0
+            @test_broken only(b.samples).evals == 4
+
+            b = @be sleep(.001) evals=4 samples=1
+            @test only(b.samples).warmup == 1
+            @test only(b.samples).evals == 4
+
+            b = @be sleep(.001) evals=4 samples=2
+            @test length(b.samples) == 2
+            @test all(s -> s.warmup == 1 && s.evals == 4, b.samples)
+        end
+
         @testset "errors" begin
             @test_throws UndefKeywordError Sample(allocs=1.5, bytes=1729) # needs `time`
         end


### PR DESCRIPTION
Fixes #91. Bug introduced by #57. The extra sample comes from calibration:

https://github.com/LilithHafner/Chairmarks.jl/blob/5aa41f9d4df13120f5d1cfba2fc210e8f3fcafc8/src/benchmarking.jl#L91-L97

So we start populating at 2 in the main loop.