### PR TITLE
Handle seconds=Inf and very high seconds args gracefully (unbounded runtime if samples and evals are specified, otherwise throw)

### DIFF
--- a/src/benchmarking.jl
+++ b/src/benchmarking.jl
@@ -19,6 +19,12 @@ maybecall(f::Function, ::Tuple{}) = (f(),)
 maybecall(x, ::Tuple{}) = (x,)
 function benchmark(init, setup, f, teardown; evals::Union{Int, Nothing}=nothing, samples::Union{Int, Nothing}=nothing, seconds::Union{Real, Nothing}=samples===nothing ? .1 : 1, gc::Bool=true, checksum::Bool=true, _map=(checksum ? default_map : Returns(nothing)), _reduction=default_reduction)
     @nospecialize
+
+    if seconds !== nothing && isinf(seconds)
+        samples === nothing && throw(ArgumentError("samples must be specified if seconds is Inf"))
+        return benchmark(init, setup, f, teardown; evals=evals, samples=samples, seconds=nothing, gc=gc, checksum=checksum, _map=_map, _reduction=_reduction)
+    end
+
     samples !== nothing && evals === nothing && throw(ArgumentError("Sorry, we don't support specifying samples but not evals"))
     samples === seconds === nothing && throw(ArgumentError("Must specify either samples or seconds"))
     evals === nothing || evals > 0 || throw(ArgumentError("evals must be positive"))

--- a/src/benchmarking.jl
+++ b/src/benchmarking.jl
@@ -20,8 +20,8 @@ maybecall(x, ::Tuple{}) = (x,)
 function benchmark(init, setup, f, teardown; evals::Union{Int, Nothing}=nothing, samples::Union{Int, Nothing}=nothing, seconds::Union{Real, Nothing}=samples===nothing ? .1 : 1, gc::Bool=true, checksum::Bool=true, _map=(checksum ? default_map : Returns(nothing)), _reduction=default_reduction)
     @nospecialize
 
-    if seconds !== nothing && isinf(seconds)
-        samples === nothing && throw(ArgumentError("samples must be specified if seconds is Inf"))
+    if seconds !== nothing && seconds >= 2.0^63*1e-9
+        samples === nothing && throw(ArgumentError("samples must be specified if seconds is infinite or nearly infinite (more than 292 years)"))
         return benchmark(init, setup, f, teardown; evals=evals, samples=samples, seconds=nothing, gc=gc, checksum=checksum, _map=_map, _reduction=_reduction)
     end
 
@@ -50,7 +50,6 @@ function benchmark(init, setup, f, teardown; evals::Union{Int, Nothing}=nothing,
     warmup, start_time = bench(1, false)
 
     seconds == 0 && return Benchmark([warmup])
-
     new_evals = if evals === nothing
         @assert evals === samples === nothing && seconds !== nothing
 
@@ -105,8 +104,8 @@ function benchmark(init, setup, f, teardown; evals::Union{Int, Nothing}=nothing,
     end
 
     i = 1
-    stop_time = seconds === nothing ? nothing : round(UInt64, start_time + 1e9seconds)
-    while (seconds === nothing || time < stop_time) && (samples === nothing || i < samples)
+    stop_time = seconds === nothing ? nothing : start_time + round(UInt64, 1e9seconds)
+    while (seconds === nothing || signed(stop_time - time) >= 0) && (samples === nothing || i < samples)
         sample, time = bench(new_evals)
         samples === nothing ? push!(data, sample) : (data[i += 1] = sample)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,9 +65,12 @@ using Chairmarks: Sample, Benchmark
             @test_throws UndefKeywordError Sample(allocs=1.5, bytes=1729) # needs `time`
 
             # 104
-            @test_throws ArgumentError("samples must be specified if seconds is Inf") @b 1+1 seconds=Inf
+            @test_throws ArgumentError("samples must be specified if seconds is infinite or nearly infinite (more than 292 years)") @b 1+1 seconds=Inf
+            @test_throws ArgumentError("samples must be specified if seconds is infinite or nearly infinite (more than 292 years)") @b 1+1 seconds=1e30
+            @test_throws ArgumentError("samples must be specified if seconds is infinite or nearly infinite (more than 292 years)") @b 1+1 seconds=293*365*24*60*60
             @test_throws ArgumentError("Must specify either samples or seconds") @b 1+1 seconds=nothing
             @test only((@be 1+1 evals=1 samples=1 seconds=Inf).samples).evals == 1
+            @test only((@be 1+1 evals=1 samples=1 seconds=1e30).samples).evals == 1
             @test only((@be 1+1 evals=1 samples=1 seconds=nothing).samples).evals == 1
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,6 +74,16 @@ using Chairmarks: Sample, Benchmark
             @test only((@be 1+1 evals=1 samples=1 seconds=nothing).samples).evals == 1
         end
 
+        @testset "time_ns() close to typemax(UInt64)" begin
+            t0 = ccall(:jl_hrtime, UInt64, ())
+            @eval Base time_ns() = ccall(:jl_hrtime, UInt64, ()) - $t0 - 10^9
+            # check that this does not throw or hang
+            # really high threshold because it's hard to avoid false positives with runtime
+            # @eval to ensure we get the latest version of time_ns()
+            @test 600 > @elapsed @eval @b 1+1 seconds=1.1
+            @eval Base time_ns() = ccall(:jl_hrtime, UInt64, ())
+        end
+
         @testset "interpolation" begin
             slow = @b length(rand(100)) evals=50
             fast = @b length($(rand(100))) evals=50

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,9 +69,9 @@ using Chairmarks: Sample, Benchmark
             @test_throws ArgumentError("samples must be specified if seconds is infinite or nearly infinite (more than 292 years)") @b 1+1 seconds=1e30
             @test_throws ArgumentError("samples must be specified if seconds is infinite or nearly infinite (more than 292 years)") @b 1+1 seconds=293*365*24*60*60
             @test_throws ArgumentError("Must specify either samples or seconds") @b 1+1 seconds=nothing
-            @test only((@be 1+1 evals=1 samples=1 seconds=Inf).samples).evals == 1
-            @test only((@be 1+1 evals=1 samples=1 seconds=1e30).samples).evals == 1
-            @test only((@be 1+1 evals=1 samples=1 seconds=nothing).samples).evals == 1
+            @test Chairmarks.only((@be 1+1 evals=1 samples=1 seconds=Inf).samples).evals == 1
+            @test Chairmarks.only((@be 1+1 evals=1 samples=1 seconds=1e30).samples).evals == 1
+            @test Chairmarks.only((@be 1+1 evals=1 samples=1 seconds=nothing).samples).evals == 1
         end
 
         @testset "time_ns() close to typemax(UInt64)" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,6 +63,12 @@ using Chairmarks: Sample, Benchmark
 
         @testset "errors" begin
             @test_throws UndefKeywordError Sample(allocs=1.5, bytes=1729) # needs `time`
+
+            # 104
+            @test_throws ArgumentError("samples must be specified if seconds is Inf") @b 1+1 seconds=Inf
+            @test_throws ArgumentError("Must specify either samples or seconds") @b 1+1 seconds=nothing
+            @test only((@be 1+1 evals=1 samples=1 seconds=Inf).samples).evals == 1
+            @test only((@be 1+1 evals=1 samples=1 seconds=nothing).samples).evals == 1
         end
 
         @testset "interpolation" begin


### PR DESCRIPTION
Fixes #104 

- handle seconds=Inf gracefully
- handle very high seconds gracefully
- handle time_ns() being close to the top of its range and overflowing mid-benchmark gracefully (with no errors)
- add tests for all of the above