### PR TITLE
Fix time conversion in BenchmarkTools comparison

### DIFF
--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -81,8 +81,8 @@ Benchmark results have the following fields:
 
 | Chairmarks             | BenchmarkTools      | Description            |
 |------------------------|---------------------|------------------------|
-| `x.time`               | `x.time*1e9`        | Runtime in seconds     |
-| `x.time/1e9`           | `x.time`            | Runtime in nanoseconds |
+| `x.time`               | `x.time/1e9`        | Runtime in seconds     |
+| `x.time*1e9`           | `x.time`            | Runtime in nanoseconds |
 | `x.allocs`             | `x.allocs`          | Number of allocations  |
 | `x.bytes`              | `x.memory`          | Number of bytes allocated across all allocations |
 | `x.gc_fraction`        | `x.gctime / x.time` | Fraction of time spent in garbage collection |


### PR DESCRIPTION
If I'm not mistaken, the time conversion in the ["Fields"](https://chairmarks.lilithhafner.com/v1.2.1/migration#Fields) table has two typos.

```Julia-repl
julia> s = @b rand(100) sum
7.854 ns

julia> s.time # in seconds
7.853748680042239e-9

julia> s.time*1e9 # in nanoseconds
7.853748680042239
```