### PR TITLE
make `show(::Benchmark)` indent samples 1 space instead of 2

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -99,7 +99,7 @@ end
 function Base.show(io::IO, b::Benchmark)
     println(io, "Benchmark([")
     for s in b.samples
-        println(io, "  ", s)
+        println(io, " ", s)
     end
     print(io, "])")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -144,6 +144,16 @@ using Chairmarks: Sample, Benchmark
                 Sample(time=0.10162322700000001, allocs=166, bytes=16584)
             ])
 
+            # 1 space indent, like Vector, even though there's two levels of nesting here.
+            @test sprint(show, x) == """
+            Benchmark([
+             Sample(time=0.10223923, allocs=166, bytes=16584)
+             Sample(time=0.101591227, allocs=166, bytes=16584)
+             Sample(time=0.10154031000000001, allocs=166, bytes=16584)
+             Sample(time=0.101644144, allocs=166, bytes=16584)
+             Sample(time=0.10162322700000001, allocs=166, bytes=16584)
+            ])"""
+
             @test eval(Meta.parse(repr(x))).samples == x.samples
             VERSION >= v"1.6" && @test sprint(show, MIME"text/plain"(), x) == """
             Benchmark: 5 samples with 1 evaluation


### PR DESCRIPTION
Includes tests and justification (alignment with Vector display).