### PR TITLE
Make flaky Issue 74 test a regression test not an absolute test

### DIFF
--- a/bench/runbenchmarks.jl
+++ b/bench/runbenchmarks.jl
@@ -80,13 +80,13 @@ VERSION > v"1.8" && @group begin "Issue 74"
     g74(x, n) = x << (n & 63)
 
     function check()
-        x = UInt128(1); n = 1;
+        x = fail74(1); n = 1;
         fres = @b f74(x, n)
         gres = @b g74(x, n)
-        fres.time > gres.time
+        fres.time <= gres.time
     end
 
-    @track sum(check() for _ in 1:10) # Needs @noinline at callsite
+    @track sum(fail74() for _ in 1:10) # Needs @noinline at callsite
 end
 
 #### Performance ####

--- a/bench/runbenchmarks.jl
+++ b/bench/runbenchmarks.jl
@@ -86,7 +86,7 @@ VERSION > v"1.8" && @group begin "Issue 74"
         fres.time <= gres.time
     end
 
-    @track sum(fail74() for _ in 1:10) # Needs @noinline at callsite
+    @track count(fail74() for _ in 1:10) # Needs @noinline at callsite
 end
 
 #### Performance ####

--- a/bench/runbenchmarks.jl
+++ b/bench/runbenchmarks.jl
@@ -79,8 +79,8 @@ VERSION > v"1.8" && @group begin "Issue 74"
     f74(x, n) = x << n
     g74(x, n) = x << (n & 63)
 
-    function check()
-        x = fail74(1); n = 1;
+    function fail74()
+        x = UInt128(1); n = 1;
         fres = @b f74(x, n)
         gres = @b g74(x, n)
         fres.time <= gres.time

--- a/bench/runbenchmarks.jl
+++ b/bench/runbenchmarks.jl
@@ -75,6 +75,19 @@ end
     @track wrong
 end
 
+VERSION > v"1.8" && @group begin "Issue 74"
+    f74(x, n) = x << n
+    g74(x, n) = x << (n & 63)
+
+    function check()
+        x = UInt128(1); n = 1;
+        fres = @b f74(x, n)
+        gres = @b g74(x, n)
+        fres.time > gres.time
+    end
+
+    @track sum(check() for _ in 1:10) # Needs @noinline at callsite
+end
 
 #### Performance ####
 

--- a/src/benchmarking.jl
+++ b/src/benchmarking.jl
@@ -121,10 +121,10 @@ function _benchmark(f::F, map::M, reduction::R, args::A, evals::Int, warmup::Boo
     ctime, time0, time1, res, acc = try
         ctime = cumulative_compile_time_ns()
         time0 = time_ns()
-        res = @static VERSION >= v"1.8" ? (f(args...)) : f(args...)
+        res = @static VERSION >= v"1.8" ? @noinline(f(args...)) : f(args...)
         acc = map(res)
         for _ in 2:evals
-            x = @static VERSION >= v"1.8" ? (f(args...)) : f(args...)
+            x = @static VERSION >= v"1.8" ? @noinline(f(args...)) : f(args...)
             acc = reduction(acc, map(x))
         end
         time1 = time_ns()

--- a/src/benchmarking.jl
+++ b/src/benchmarking.jl
@@ -121,10 +121,10 @@ function _benchmark(f::F, map::M, reduction::R, args::A, evals::Int, warmup::Boo
     ctime, time0, time1, res, acc = try
         ctime = cumulative_compile_time_ns()
         time0 = time_ns()
-        res = @static VERSION >= v"1.8" ? @noinline(f(args...)) : f(args...)
+        res = @static VERSION >= v"1.8" ? (f(args...)) : f(args...)
         acc = map(res)
         for _ in 2:evals
-            x = @static VERSION >= v"1.8" ? @noinline(f(args...)) : f(args...)
+            x = @static VERSION >= v"1.8" ? (f(args...)) : f(args...)
             acc = reduction(acc, map(x))
         end
         time1 = time_ns()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -303,20 +303,6 @@ using Chairmarks: Sample, Benchmark
             @test_broken (@b 1).time == 0
             @test_broken (@b 123908).time == 0
         end
-
-        @testset "Issue 74" begin
-            f74(x, n) = x << n
-            g74(x, n) = x << (n & 63)
-
-            function check()
-                x = UInt128(1); n = 1;
-                fres = @b f74(x, n)
-                gres = @b g74(x, n)
-                fres.time > gres.time
-            end
-
-            VERSION > v"1.8" && @test sum(check() for _ in 1:10) >= 8 # Needs @noinline at callsite
-        end
     end
 
     @testset "Performance" begin


### PR DESCRIPTION
This is necessary because the test fails every once in a while so we need to wrap it in RegressionTests.jl to avoid false positives. The downside is it could slide slowly.

See #74, #75