### PR TITLE
Macro Expansion: Special case QuoteNode by `Returns`ing the unpacked value rather than the QuoteNode itself.

### DIFF
--- a/bench/runbenchmarks.jl
+++ b/bench/runbenchmarks.jl
@@ -97,7 +97,7 @@ end
 @group begin "no compilation"
     res = @b @eval (@b 100 rand seconds=.001)
     @track res.time
-    @track res.compile_fraction < 1e-4 # A bit of compile time is necessary because of the @eval
+    @track res.compile_fraction > 1e-4 # A bit of compile time is necessary because of the @eval
 end
 
 @group begin "bignums don't explode in the reduction"

--- a/src/macro_tools.jl
+++ b/src/macro_tools.jl
@@ -48,7 +48,8 @@ create_first_function(f::Symbol) = f
 # itself, using `Returns` is semantically equivalent to the documented behavior. Assuming
 # that we prevent constant propagation elsewhere it should produce equivalent measurements.
 create_first_function(x) = Returns(x)
-create_first_function(body::Union{QuoteNode, Expr}) = :(() -> $body)
+create_first_function(x::QuoteNode) = Returns(x.value)
+create_first_function(body::Expr) = :(() -> $body)
 function create_function(f)
     f === :_ && return identity
     var = gensym()

--- a/src/macro_tools.jl
+++ b/src/macro_tools.jl
@@ -43,7 +43,12 @@ function extract_interpolations!(interpolations, expr::Expr)
 end
 
 create_first_function(f::Symbol) = f
-create_first_function(body) = :(() -> $body)
+# We use `Returns` to reduce compile time by using fewer anonomous functions.
+# Assumeing that any value in an expression tree other than Expr or QuoteNode `eval`s to
+# itself, using `Returns` is semantically equivalent ot the documented behavior. Assuming
+# that we prevent constant propigation elsewhere it should produce equivalent measurements.
+create_first_function(x) = Returns(x)
+create_first_function(body::Union{QuoteNode, Expr}) = :(() -> $body)
 function create_function(f)
     f === :_ && return identity
     var = gensym()

--- a/src/macro_tools.jl
+++ b/src/macro_tools.jl
@@ -43,10 +43,10 @@ function extract_interpolations!(interpolations, expr::Expr)
 end
 
 create_first_function(f::Symbol) = f
-# We use `Returns` to reduce compile time by using fewer anonomous functions.
+# We use `Returns` to reduce compile time by using fewer anonymous functions.
 # Assumeing that any value in an expression tree other than Expr or QuoteNode `eval`s to
-# itself, using `Returns` is semantically equivalent ot the documented behavior. Assuming
-# that we prevent constant propigation elsewhere it should produce equivalent measurements.
+# itself, using `Returns` is semantically equivalent to the documented behavior. Assuming
+# that we prevent constant propagation elsewhere it should produce equivalent measurements.
 create_first_function(x) = Returns(x)
 create_first_function(body::Union{QuoteNode, Expr}) = :(() -> $body)
 function create_function(f)

--- a/src/macro_tools.jl
+++ b/src/macro_tools.jl
@@ -43,8 +43,7 @@ function extract_interpolations!(interpolations, expr::Expr)
 end
 
 create_first_function(f::Symbol) = f
-create_first_function(x) = Returns(x)
-create_first_function(body::Expr) = :(() -> $body)
+create_first_function(body) = :(() -> $body)
 function create_function(f)
     f === :_ && return identity
     var = gensym()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -246,6 +246,10 @@ using Chairmarks: Sample, Benchmark
                     100.000 ms
                     100.000 ms"""
         end
+
+        @testset "Issue 99" begin
+            @b :my_func isdefined(Main, _) seconds=.001
+        end
     end
 
     @testset "Statistics Extension" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -324,6 +324,14 @@ using Chairmarks: Sample, Benchmark
     end
 
     @testset "Performance" begin
+        @testset "no compilation" begin
+            res = @b @eval @b 100 rand seconds=.001
+            @test res.compile_fraction < .1
+            @eval _Chairmarks_test_isdefined_in_Main(x) = isdefined(Main, x)
+            res = @b @eval @b :my_func _Chairmarks_test_isdefined_in_Main seconds=.001
+            @test res.compile_fraction < .1
+        end
+
         ### Begin stuff that doesn't run
 
         function verbose_check(baseline, test, tolerance)


### PR DESCRIPTION
Fixes #99.

This special case assumes that all non-Expr objects in an expression tree evaluate to themselves. This is a false assumption in the case of `QuoteNode(::Symbol)`.

Additionally, this `Returns` gives the compiler slightly less information by inhibiting constant propagation of literals. Constant propagation of literals is usually bad (misleadingly low runtimes) in this case but this particular fix also results in `@b 2 rand` and `@b 1+1 rand` having different properties with the _latter_ more constprop-able. I was not able to find a case where the `Returns` is helpful.

Returns was added in 4f8a8c8bb0635b53a0162d3958a7c24430d7766d to avoid compilation time and paired with the test
```julia
@testset "no compilation" begin
    res = @b @eval (@b 100 rand seconds=.001)
    @test .001 < 1e-9res.time < .002
    @test res.compile_fraction === 0.0
end
```

I expect the "no compilation" regression test to regress.