### PR TITLE
Support `Chairmarks.DEFAULTS.seconds`

### DIFF
--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -52,6 +52,7 @@ Here are some examples of corresponding invocations in BenchmarkTools and Chairm
 | `@btime sort!(x, rev=true) setup=(x=rand(100)) evals=1;` | `@b rand(100) sort!(_, rev=true) evals=1` |
 | `@btime issorted(sort!(x)) \|\| error() setup=(x=rand(100)) evals=1` | `@b rand(100) sort! issorted(_) \|\| error() evals=1` |
 | `let X = rand(100); @btime issorted(sort!($X)) \|\| error() setup=(rand!($X)) evals=1 end` | `@b rand(100) rand! sort! issorted(_) \|\| error() evals=1` |
+| `BenchmarkTools.DEFAULT_PARAMETERS.seconds = 1` | `Chairmarks.DEFAULTS.seconds = 1` |
 
 For automated regression tests, [RegressionTests.jl](https://github.com/LilithHafner/RegressionTests.jl)
 is a work in progress replacement for the `BenchmarkGroup` and `@benchmarkable` system.

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -12,10 +12,12 @@ version number if the change is not expected to cause significant disruptions.
 - [`Chairmarks.Benchmark`](@ref)
 - [`@b`](@ref)
 - [`@be`](@ref)
+- [`Chairmarks.DEFAULTS`](@ref)
 
 ```@docs
 Chairmarks.Sample
 Chairmarks.Benchmark
 @b
 @be
+Chairmarks.DEFAULTS
 ```

--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -252,9 +252,9 @@ sure it's reasonably stable.
 ## Advanced usage
 
 It is possible to manually specify the number of evaluations, samples, and/or seconds to run
-benchmarking for. It is also possible to pass a teardown function or an initialization
-function that runs only once. See the docstring of [`@be`](@ref) for more information on
-these additional arguments.
+benchmarking for and configure the default benchmarking runtime. It is also possible to pass
+a teardown function or an initialization function that runs only once. See the docstring of
+[`@be`](@ref) for more information on these additional arguments.
 
 [^1]: note that the samples are aggregated element wise, so the max field reports the maximum
     runtime and the maximum proportion of runtime spent in garbage collection (gc). Thus it

--- a/src/Chairmarks.jl
+++ b/src/Chairmarks.jl
@@ -17,7 +17,7 @@ module Chairmarks
 
 using Printf
 
-VERSION >= v"1.11.0-DEV.469" && eval(Meta.parse("public Sample, Benchmark"))
+VERSION >= v"1.11.0-DEV.469" && eval(Meta.parse("public Sample, Benchmark, DEFAULTS"))
 export @b, @be
 
 include("types.jl")

--- a/src/benchmarking.jl
+++ b/src/benchmarking.jl
@@ -17,7 +17,14 @@ maybecall(::Nothing, x::Tuple{}) = x
 maybecall(f, x::Tuple{Any}) = (f(only(x)),)
 maybecall(f::Function, ::Tuple{}) = (f(),)
 maybecall(x, ::Tuple{}) = (x,)
-function benchmark(init, setup, f, teardown; evals::Union{Int, Nothing}=nothing, samples::Union{Int, Nothing}=nothing, seconds::Union{Real, Nothing}=samples===nothing ? .1 : 1, gc::Bool=true, checksum::Bool=true, _map=(checksum ? default_map : Returns(nothing)), _reduction=default_reduction)
+function benchmark(init, setup, f, teardown;
+        evals::Union{Int, Nothing}=nothing,
+        samples::Union{Int, Nothing}=nothing,
+        seconds::Union{Real, Nothing}=samples===nothing ? DEFAULTS.seconds : 10*DEFAULTS.seconds,
+        gc::Bool=DEFAULTS.gc,
+        checksum::Bool=true,
+        _map=(checksum ? default_map : Returns(nothing)),
+        _reduction=default_reduction)
     @nospecialize
 
     if seconds !== nothing && seconds >= 2.0^63*1e-9

--- a/src/public.jl
+++ b/src/public.jl
@@ -217,7 +217,7 @@ A global constant that holds default benchmarking parameters.
 When a parameter is unspecified it defaults to the value stored in `Chairmarks.DEFAULTS`.
 
 Currently there is one stable default: `Chairmarks.DEFAULTS.seconds::Float64` which defaults
-to 0.1; and one expiremental default: `Chairmarks.DEFAULTS.gc::Bool` which defaults to
+to 0.1; and one experimental default: `Chairmarks.DEFAULTS.gc::Bool` which defaults to
 `true`.
 
 All default values may be changed in the future and the `gc` default may be removed

--- a/src/public.jl
+++ b/src/public.jl
@@ -93,14 +93,18 @@ arguments to ordinary functions. Keyword arguments to control executions are
   - `samples::Integer` Maximum number of samples to take. Defaults to unlimited and cannot
     be specified without also specifying `evals`. Specifying `samples = 0` will cause `@be`
     to run the warmup sample only and return that sample.
-  - `seconds::Real` Maximum amount of time to spend benchmarking. Defaults to `0.1` seconds
-    unless `samples` is specified in which case it defaults to `1` second. Set to `Inf`
-    to disable the time limit. Compile time is typically not counted against this limit.
-    A reasonable effort is made to respect the time limit, but it is always exceeded by a
-    small about (less than 1%) and can be significantly exceeded when benchmarking long
-    running functions.
+  - `seconds::Real` Maximum amount of time to spend benchmarking. Defaults to
+    [`Charimarks.DEFAULTS.seconds`](@ref Chairmarks.DEFAULTS) (which is `0.1` by default)
+    unless `samples` is specified, in which case it defaults to 10 times as long (1 second,
+    by default). Users are free to modify Charimarks.DEFAULTS.seconds for their own
+    interactive usage and its default value may change in the future. Set to `Inf` to
+    disable the time limit. Compile time is typically not counted against this limit. A
+    reasonable effort is made to respect the time limit but if samples is unspecified it is
+    always exceeded by a small about (less than 1%) and can be significantly exceeded when
+    benchmarking long running functions.
   - `gc::Bool` An experimental option to disable garbage collection during benchmarking.
-    Defaults to `true`. Set to `false` to garbage collection during benchmarking. Disabling
+    Defaults to [`Charimarks.DEFAULTS.gc`](@ref Chairmarks.DEFAULTS) which is `true` by
+    default. Set to `false` to disable garbage collection during benchmarking. Disabling
     garbage collection may cause out of memory errors during a benchmark that requires
     garbage collection, but should not result in memory leaks that survive past the end of
     the benchmark. As an experimental option, this may be removed in the future or its
@@ -204,3 +208,19 @@ Benchmark: 1 sample with 1 evaluation
 macro be(args...)
     process_args(args)
 end
+
+"""
+    Chairmarks.DEFAULTS
+
+A global constant that holds default benchmarking parameters.
+
+When a parameter is unspecified it defaults to the value stored in `Chairmarks.DEFAULTS`.
+
+Currently there is one stable default: `Chairmarks.DEFAULTS.seconds::Float64` which defaults
+to 0.1; and one expiremental default: `Chairmarks.DEFAULTS.gc::Bool` which defaults to
+`true`.
+
+All default values may be changed in the future and the `gc` default may be removed
+entirely.
+"""
+const DEFAULTS = Defaults(0.1, true)

--- a/src/types.jl
+++ b/src/types.jl
@@ -71,3 +71,13 @@ julia> minimum(ans)
 struct Benchmark
     samples::Vector{Sample}
 end
+
+"""
+    mutable struct Defaults
+
+The type of [`Chairmarks.DEFAULTS`](@ref)
+"""
+mutable struct Defaults
+    seconds::Float64
+    gc::Bool
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -144,6 +144,15 @@ using Chairmarks: Sample, Benchmark
             @test Chairmarks.writefixed(-0.005, 4) == "-0.0050"
         end
 
+        @testset "DEFAULTS" begin
+            @test Chairmarks.DEFAULTS.seconds === 0.1
+            @test Chairmarks.DEFAULTS.gc === true
+            Chairmarks.DEFAULTS.seconds = 1
+            @test Chairmarks.DEFAULTS.seconds === 1.0
+            @test 1 <= @elapsed @b 1+1
+            Chairmarks.DEFAULTS.seconds = 0.1
+            @test Chairmarks.DEFAULTS.seconds === 0.1
+        end
         @testset "display" begin
 
             # Basic


### PR DESCRIPTION
Implements and closes #71 by providing a global default mechanism: `Chairmarks.DEFAULTS.seconds = 1`.