### PR TITLE
Remove checksum plumbing and configurability

### DIFF
--- a/bench/runbenchmarks.jl
+++ b/bench/runbenchmarks.jl
@@ -128,12 +128,6 @@ end
     t = @elapsed @b rand Returns(float(x))
     @test t > .1
     @track t - .1
-    t = @elapsed @b rand Returns(float(x)) _map=identity
-    @test t > .1
-    @track t - .1
-    t = @elapsed @b rand Returns(float(x)) _map=identity
-    @test t > .1
-    @track t - .1
 end
 
 @group begin "very fast runtimes"

--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -91,7 +91,6 @@ Benchmark results have the following fields:
 | `x.compile_fraction`   | N/A                 | Fraction of time spent compiling |
 | `x.recompile_fraction` | N/A                 | Fraction of time spent compiling which was on recompilation |
 | `x.warmup`             | `true`              | whether or not the sample had a warmup run before it |
-| `x.checksum`           | N/A                 | a checksum computed from the return values of the benchmarked code |
 | `x.evals`              | `x.params.evals`    | the number of evaluations in the sample |
 
 Note that more fields may be added as more information becomes available.

--- a/docs/src/why.md
+++ b/docs/src/why.md
@@ -94,32 +94,15 @@ See [`@be`](@ref) for more info
 ## Truthful
 
 On versions of Julia prior to 1.8, Chairmarks automatically computes a checksum based on the
-results of the provided computations and returns that checksum to the user along with
-benchmark results. This makes it impossible for the compiler to elide any part of the
-computation that has an impact on its return value.
+results of the provided computations and stores the checksum in Chiarmaks.CHECKSUM. This
+makes it impossible for the compiler to elide any part of the computation that has an impact
+on its return value.
 
-While the checksums are fast, one negative side effect of this is that they add a bit of
-overhead to the measured runtime, and that overhead can vary depending on the function being
-benchmarked. In versions of Julia 1.8 and later, these checksums are emulated using the
-function `Base.donotdelete` which is designed and documented to ensure that necessary
-computation is not elided without adding extra overhead. You can disable all of this on all
-versions of Julia by passing the `checksum=false` keyword argument, possibly in combination
-with a custom teardown function that verifies computation results. Be aware that as the
-compiler improves, it may become better at eliding benchmarks whose results are not saved.
-
-
-```jldoctest; filter=r"\d\d?\d?\.\d{3} [μmn]?s( \(.*\))?|0 ns|<0.001 ns"
-julia> @b rand hash
-2.276 ns
-
-julia> @b rand hash checksum=false
-0 ns
-```
-
-You may experiment with custom reductions using the internal `_map` and `_reduction` keyword
-arguments. The default maps and reductions (`Chairmarks.default_map` and
-`Chairmarks.default_reduction`) are internal and subject to change and/or removal in
-the future.
+While the checksums are reasonably fast, one negative side effect of this is that they add a
+bit of overhead to the measured runtime, and that overhead can vary depending on the
+return value of the function being benchmarked. In versions of Julia 1.8 and later, these
+checksums are emulated using the function `Base.donotdelete` which is designed and
+documented to ensure that necessary computation is not elided without adding extra overhead.
 
 ## Innate qualities
 

--- a/src/benchmarking.jl
+++ b/src/benchmarking.jl
@@ -4,8 +4,8 @@ using Random: randperm
 @static if v"1.8" <= VERSION
     const donotdelete = Base.donotdelete
 else
-    const STATE = Ref{UInt}()
-    donotdelete(x) = (STATE[] = hash(x, STATE[]); nothing)
+    const CHECKSUM = Ref{UInt}()
+    donotdelete(x) = (CHECKSUM[] = hash(x, CHECKSUM[]); nothing)
 end
 
 benchmark(f; kw...) = benchmark(nothing, f; kw...)

--- a/src/types.jl
+++ b/src/types.jl
@@ -8,7 +8,6 @@
         compile_fraction   ::Float64 # The fraction of time spent compiling (0.0 to 1.0)
         recompile_fraction ::Float64 # The fraction of compile time which was, itself, recompilation (0.0 to 1.0)
         warmup             ::Float64 # Whether this sample had a warmup run before it (1.0 = yes. 0.0 = no).
-        checksum           ::Float64 # A checksum based on the values returned by the benchmarked function
         ...more fields may be added...
     end
 
@@ -35,11 +34,9 @@ struct Sample
     recompile_fraction ::Float64
     "Whether this sample had a warmup run before it (1.0 = yes. 0.0 = no)."
     warmup             ::Float64
-    "A checksum based on the values returned by the benchmarked function"
-    checksum           ::Float64
 end
-Sample(; evals=1, time, allocs=0, bytes=0, gc_fraction=0, compile_fraction=0, recompile_fraction=0, warmup=true, checksum=0) =
-    Sample(evals, time, allocs, bytes, gc_fraction, compile_fraction, recompile_fraction, warmup, checksum)
+Sample(; evals=1, time, allocs=0, bytes=0, gc_fraction=0, compile_fraction=0, recompile_fraction=0, warmup=true) =
+    Sample(evals, time, allocs, bytes, gc_fraction, compile_fraction, recompile_fraction, warmup)
 
 """
     struct Benchmark

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,22 +87,19 @@ using Chairmarks: Sample, Benchmark
         @testset "interpolation" begin
             slow = @b length(rand(100)) evals=50
             fast = @b length($(rand(100))) evals=50
-            @test slow.checksum == fast.checksum
             @test slow.allocs > 0
             @test fast.allocs == 0
             @test 2fast.time < slow.time # should be about 3000x
 
             global interpolation_test_global = 1
-            slow = @b interpolation_test_global + 1 evals=300 # evals must be specified for checksums to match
-            fast = @b $interpolation_test_global + 1 evals=300
-            @test slow.checksum == fast.checksum
+            slow = @b interpolation_test_global + 1
+            fast = @b $interpolation_test_global + 1
             @test slow.allocs > 0 || VERSION > v"1.12.0-DEV" # This doesn't allocate in 1.12.
             @test fast.allocs == 0
             @test 2fast.time < slow.time # should be about 100x
 
             a = @b 6 $interpolation_test_global + $interpolation_test_global + _ evals=42
             b = @b 8 evals=42
-            @test a.checksum == b.checksum
         end
 
         @testset "gc=false" begin


### PR DESCRIPTION
- **Remove checksum mechanics because Base.donotdelete is more appropriate since 1.8**
- **Update docs**

Technically breaking because the `checksum=false` kwarg now throws.

Folks can still use teardown.