### PR TITLE
Eliminate reported fractional allocations in the case of nonconstant global access

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -362,7 +362,7 @@ using Random: rand!
             @b :my_func isdefined(Main, _) seconds=.001
         end
 
-        @testset "Issue #128, fractional allocations in the presence of nonconstant globals" begin
+        @testset "Issue #128, fractional allocs" begin  # in the presence of nonconstant globals
             x = randn(100, 2);
 
             function foo(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,7 +106,6 @@ using Random: rand!
             global interpolation_test_global = 1
             slow = @b interpolation_test_global + 1
             fast = @b $interpolation_test_global + 1
-            @test slow.allocs > 0 || VERSION > v"1.12.0-DEV" # This doesn't allocate in 1.12.
             @test fast.allocs == 0
             @test 2fast.time < slow.time # should be about 100x
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -358,8 +358,28 @@ using Random: rand!
                     100.000 ms"""
         end
 
-        @testset "Issue 99" begin
+        @testset "Issue #99" begin
             @b :my_func isdefined(Main, _) seconds=.001
+        end
+
+        @testset "Issue #128, fractional allocations in the presence of nonconstant globals" begin
+            x = randn(100, 2);
+
+            function foo(x)
+                y = x .+ x
+                return 2 .* y
+            end
+
+            @test isinteger((@b foo(x) seconds=.001).allocs)
+
+            function foo2(x)
+                2 .* (x .+ x)
+            end
+
+            @test isinteger((@b foo2(x) seconds=.001).allocs)
+
+            x = 1
+            @test isinteger((@b hash(x) seconds=.001).allocs)
         end
     end
 


### PR DESCRIPTION
Move gcstats inside compile time tracking because compile time tracking allocates in the event of type instability due to tuple construction used to pass results out of the try-catch block.

Fixes #128