### PR TITLE
Stop pretending to run RegressionTests on main

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,6 +87,7 @@ jobs:
           files: lcov.info
   regression-tests:
     needs: quick-test
+    if: github.event_name == 'pull request'
     name: RegressionTests.jl Julia ${{ matrix.julia-version }} - ${{ matrix.os }} - ${{ matrix.julia-arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
RegressionTests is comparing main's HEAD to itself on pushes. Previously I let this slide because I appreciated stress testing RegressionTests for false positives. RegressionTests has not reported a false positive comparing a commit to itself in ages so it's time to stop wasting CI on this.

In the future, perhaps we can add these back and make them compare to the previous commit.