### PR TITLE
Release 1.3.0!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Chairmarks"
 uuid = "0ca39b1e-fe0b-4e98-acfc-b1656634c4de"
 authors = ["Lilith Orion Hafner <lilithhafner@gmail.com> and contributors"]
-version = "1.2.2"
+version = "1.3.0"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"


### PR DESCRIPTION
This is a big release. It also includes some technically breaking changes.

The biggest breaking change is adding comparative bench-marking which changes parsing syntax for cases where f is a comma separated list already.

For example,

```julia
@b rand(),rand()
```
Used to expand to
```julia
:((Chairmarks.benchmark)((()->(rand(), rand())); ))
```
and now expands to
```julia
:((Chairmarks.benchmark)(((()->rand()), (()->rand())); ))
```
which returns an `NTuple{2, Benchmark}` instead of a `Benchmark`.

Practically, I think this will not adversely impact folks and if it does, it would be perfectly fine to revert it in 1.3.1 and re-release as 2.0.0 because the whole comparative benchmarking scheme is experimental. 