### PR TITLE
Keep old 9-arg sample constructor and discard checksum

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -38,6 +38,10 @@ end
 Sample(; evals=1, time, allocs=0, bytes=0, gc_fraction=0, compile_fraction=0, recompile_fraction=0, warmup=true) =
     Sample(evals, time, allocs, bytes, gc_fraction, compile_fraction, recompile_fraction, warmup)
 
+# For compatibility; older versions of Chairmarks accepted this form.
+Sample(evals, time, allocs, bytes, gc_fraction, compile_fraction, recompile_fraction, warmup, checksum) =
+    Sample(evals, time, allocs, bytes, gc_fraction, compile_fraction, recompile_fraction, warmup)
+
 """
     struct Benchmark
         samples::Vector{Sample}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -463,6 +463,10 @@ else
         @testset "Issue #107, specialization" begin
             @test (@b Int rand).allocs == 0
         end
+
+        @testset "Issue #156, compat with old constructor" begin
+            @test Chairmarks.Sample(0,fill(NaN, 8)...) isa Chairmarks.Sample
+        end
     end
 
     @testset "Statistics Extension" begin


### PR DESCRIPTION
Fixes #156 