### PR TITLE
fix (?) links to docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![Coverage](https://codecov.io/gh/LilithHafner/Chairmarks.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/LilithHafner/Chairmarks.jl)
 [![Aqua](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
-Chairmarks measures performance [hundreds of times faster](https://Chairmarks.lilithhafner.com/stable/why/#Efficient)
-than BenchmarkTools [without compromising on accuracy](https://Chairmarks.lilithhafner.com/stable/why/#Precise).
+Chairmarks measures performance [hundreds of times faster](https://Chairmarks.lilithhafner.com/stable/why#Efficient)
+than BenchmarkTools [without compromising on accuracy](https://Chairmarks.lilithhafner.com/stable/why#Precise).
 
 Installation
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![Coverage](https://codecov.io/gh/LilithHafner/Chairmarks.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/LilithHafner/Chairmarks.jl)
 [![Aqua](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
-Chairmarks measures performance [hundreds of times faster](https://Chairmarks.lilithhafner.com/stable/why#Efficient)
-than BenchmarkTools [without compromising on accuracy](https://Chairmarks.lilithhafner.com/stable/why#Precise).
+Chairmarks measures performance [hundreds of times faster](https://Chairmarks.lilithhafner.com/stable/why#efficient)
+than BenchmarkTools [without compromising on accuracy](https://Chairmarks.lilithhafner.com/stable/why#precise).
 
 Installation
 


### PR DESCRIPTION
For reasons I don't fully comprehend, as currently written, these links point to an old version of the docs.