### PR TITLE
Mention `@ballocations` of BenchmarkTools.jl in migration.md

### DIFF
--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -70,7 +70,7 @@ diverse base API.
 | `@benchmark`            | `@be`              | N/A            |
 | `@belapsed`             | `(@b _).time`      | `@elapsed`     |
 | `@btime`                | `display(@b _); _` | `@time`        |
-| N/A                     | `(@b _).allocs`    | `@allocations` |
+| `@ballocations`         | `(@b _).allocs`    | `@allocations` |
 | `@ballocated`           | `(@b _).bytes`     | `@allocated`   |
 | `@benchmarkable`        | `()->@be`          | N/A            |
 


### PR DESCRIPTION
Since version [v1.6.0](https://github.com/JuliaCI/BenchmarkTools.jl/releases/tag/v1.6.0), BenchmarkTools.jl has [added macros `@btimed` and `@ballocations`](https://github.com/JuliaCI/BenchmarkTools.jl/pull/383). So, the "N/A" is no longer valid in the docs. I wish this change could be reflected in the docs here, too. Thank you in advance!