### PR TITLE
Stop saying that we avoid a memory leak

### DIFF
--- a/docs/src/explanations.md
+++ b/docs/src/explanations.md
@@ -43,10 +43,7 @@ A few reasons
 - Chairmarks runs its arguments as functions in the scope that the benchmark was invoked
   from, rather than `eval`ing them at global scope. This makes it possible to get
   significant performance speedups for fast benchmarks by putting the benchmarking itself
-  into a function. It also avoids leaking memory on repeated invocations of a benchmark,
-  which is unavoidable with BenchmarkTools.jl's design.
-  ([discourse](https://discourse.julialang.org/t/memory-leak-with-benchmarktools/31282),
-  [github](https://github.com/JuliaCI/BenchmarkTools.jl/issues/339))
+  into a function.
 - Because Charimarks does not use toplevel eval, it can run arbitrarily quickly, as limited
   by a user's noise tolerance. Consequently, the auto-tuning algorithm is tuned for low
   runtime budgets in addition to high budgets so its precision doesn't degrade too much at


### PR DESCRIPTION
Because @willow-ahrens fixed this leak in a non-breaking release of BenchmarkTools so it was apparently not unavoidable. (https://github.com/JuliaCI/BenchmarkTools.jl/pull/385)